### PR TITLE
Change installing method fot csslint/jshint for syntastic

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -43,8 +43,21 @@ Bundle 'Raimondi/delimitMate'
 " many false positive but still usefull
 Bundle 'scrooloose/syntastic'
 " Install jshint and csslint for syntastic
-silent !type jshint &>/dev/null || { cd ~; echo 'Installing jshint'; npm install jshint; cd -; }
-silent !type csslint &>/dev/null || { cd ~; echo 'Installing csslint'; npm install csslint; cd -; }
+" Path to jshint if it not installed globally, then use local installation
+if !executable("jshint")
+    let g:syntastic_jshint_exec = '~/.vim/node_modules/.bin/jshint'
+    "let g:syntastic_javascript_jshint_exec = '~/.vim/node_modules/.bin/jshint'
+    if !executable(expand(g:syntastic_jshint_exec))
+        silent ! echo 'Installing jshint' && npm --prefix ~/.vim/ install jshint
+    endif
+endif
+" Path to csslint if it not installed globally, then use local installation
+if !executable("csslint")
+    let g:syntastic_css_csslint_exec='~/.vim/node_modules/.bin/csslint'
+    if !executable(expand(g:syntastic_css_csslint_exec))
+        silent ! echo 'Installing csslint' && npm --prefix ~/.vim/ install csslint
+    endif
+endif
 
 " Great file system explorer, it appears when you open dir in vim
 " Allow modification of dir, and may other things


### PR DESCRIPTION
Now, vim check if global installation exists, then use it, if not,
then install csslint/jshint into ~/.vim/node_modules directory and use it
without relying on $PATH variable
